### PR TITLE
Fix QR parsing with whitespace handling

### DIFF
--- a/frontend-frequencia/src/components/AdminLeitorQR.js
+++ b/frontend-frequencia/src/components/AdminLeitorQR.js
@@ -11,15 +11,16 @@ const COLORS = {
 
 function parseQR(qr) {
   if (!qr) return { qrcode_id: null, tipo: null };
-  
-  const parts = qr.split("-");
+
+  const cleaned = qr.trim();
+  const parts = cleaned.split("-");
   if (parts.length >= 2) {
-    return { 
+    return {
       qrcode_id: parts.slice(0, -1).join("-"),
       tipo: parts[parts.length - 1]
     };
   }
-  return { qrcode_id: qr, tipo: "entrada" };
+  return { qrcode_id: cleaned, tipo: "entrada" };
 }
 
 // Detecção melhorada de PWA


### PR DESCRIPTION
## Summary
- trim QR code before splitting in `AdminLeitorQR`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484d905ac48332a610f06d3de7aeb1